### PR TITLE
chore: stop checking go version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,13 @@
 
 VERSION = 1.0.0
 
-GO-VERSION = 1.22.0
-GO-VER = go$(GO-VERSION)
-
 SRC = $(shell find . -name "*.go" | grep -v "_test\." )
 
 .PHONY: help
 help: ## list Makefile targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build: version download checkfmt checkimports vet $(SRC) ## build the provider
+build: download checkfmt checkimports vet $(SRC) ## build the provider
 	goreleaser build --rm-dist --snapshot
 
 .PHONY: clean
@@ -20,7 +17,7 @@ clean: ## clean up build artifacts
 	- rm -rf /tmp/tpcsbsqlserver-coverage.out
 
 .PHONY: test
-test: version download checkfmt checkimports vet ginkgo ## run all build, static analysis, and test steps
+test: download checkfmt checkimports vet ginkgo ## run all build, static analysis, and test steps
 
 .PHONY: ginkgo
 ginkgo: ## run the tests with Ginkgo
@@ -54,11 +51,3 @@ checkimports: ## check that imports are formatted correctly
 fmt: ## format the code
 	gofmt -s -e -l -w .
 	go run golang.org/x/tools/cmd/goimports -l -w .
-
-.PHONY: version
-version:
-	@@go version
-	@@if [ "$$(go version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$(go version | awk '{print $$3}')"; \
-		exit 1; \
-	fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/terraform-provider-csbsqlserver
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
[#187027977](https://www.pivotaltracker.com/story/show/187027977)

Before Go 1.21:
- The go directive was advisory only; now it is a mandatory requirement
- The go directive didn't allow specifying patch versions

So, by specifying the patch version in go.mod:
- Noone can unknowingly test, run or build this project using an older version of go
- The required Go toolchain can be downloaded automatically

Therefore, checking the current go version in Makefile is no longer needed.

### Checklist:

* [ ] Have you added Release Notes in the docs repository?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
