### PR TITLE
chore: fix test cleanup timeout

### DIFF
--- a/testhelpers/server.go
+++ b/testhelpers/server.go
@@ -65,7 +65,7 @@ func runServerOrFail(password string, port int, cmd *exec.Cmd) ShutdownServerFn 
 		}
 	}
 	return func(duration time.Duration) {
-		session.Terminate().Wait(duration)
+		session.Kill().Wait(duration)
 	}
 }
 


### PR DESCRIPTION
Test were failing in cleanup. To cleanup we were sending a SIGTERM to docker, for some undiagnosed reason this has started hanging - or taking longer than 60 seconds to shutdown. Likely due to a later version of the image that we use. This has been changed to a SIGKILL.

https://vmw-jira.broadcom.net/browse/TNZ-35264

### Checklist:

* [ ] Have you added Release Notes in the docs repository?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?
