### PR TITLE
chore: apply fixes from Go modernize command

### DIFF
--- a/csbsqlserver/binding_resource_object_reassign_test.go
+++ b/csbsqlserver/binding_resource_object_reassign_test.go
@@ -4,15 +4,14 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-
+	"github.com/cloudfoundry/terraform-provider-csbsqlserver/testhelpers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
-	"github.com/cloudfoundry/terraform-provider-csbsqlserver/testhelpers"
+	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("csbsqlserver_binding resource", func() {
@@ -527,14 +526,7 @@ func findSchemaByOwner(db *sql.DB, entityOwner string, expectedSchemaName string
 		return false, rows.Err()
 	}
 
-	found := false
-	for _, schema := range schemas {
-		if schema == expectedSchemaName {
-			found = true
-			break
-		}
-	}
-	return found, nil
+	return slices.Contains(schemas, expectedSchemaName), nil
 }
 
 func getCreateTableSQL(tableName string) string {


### PR DESCRIPTION
The modernize command replaces old constructs with simpler, updated ones.

Command is:
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...